### PR TITLE
Write JSON keys in camelCase by default

### DIFF
--- a/src/JsonGridItem.cs
+++ b/src/JsonGridItem.cs
@@ -10,6 +10,7 @@ namespace JsonTreeViewEditor
         [ObservableProperty] private string? _valueTranslation;
 
         public string DisplayName { get; set; }
+        public string OriginalName { get; set; }
         public string Path { get; set; }
         public JsonElement Parent { get; set; }
         public JsonProperty JsonProperty { get; set; }
@@ -22,6 +23,7 @@ namespace JsonTreeViewEditor
         public JsonGridItem(JsonContentTranslator.JsonTreeNode node, JsonElement element, JsonProperty prop)
         {
             DisplayName = prop.Name.CapitalizeFirstLetter();
+            OriginalName = prop.Name;
             Path = $"{node.DisplayName}.{prop.Name}".ToLowerInvariant();
             Node = node;
             ValueOriginal = prop.Value.GetString();

--- a/src/JsonTreeNode.cs
+++ b/src/JsonTreeNode.cs
@@ -10,6 +10,7 @@ namespace JsonContentTranslator
     public class JsonTreeNode
     {
         public string DisplayName { get; set; }
+        public string OriginalName { get; set; }
         public ObservableCollection<JsonTreeNode> Children { get; set; }
         public List<JsonGridItem> Properties { get; set; }
         public JsonElement Element { get; internal set; }
@@ -18,14 +19,15 @@ namespace JsonContentTranslator
         public JsonTreeNode()
         {
             DisplayName = string.Empty;
+            OriginalName = string.Empty;
             Dictionary<string, object> properties = new();
             Children = new ObservableCollection<JsonTreeNode>();
             Properties = new List<JsonGridItem>();
         }
 
-        public string ConvertTreeToJson()
+        public string ConvertTreeToJson(bool useCamelCase = true)
         {
-            var jsonObject = BuildObjectFromNode(this);
+            var jsonObject = BuildObjectFromNode(this, useCamelCase);
             var options = new JsonSerializerOptions
             {
                 WriteIndented = true,
@@ -34,7 +36,18 @@ namespace JsonContentTranslator
             return JsonSerializer.Serialize(jsonObject, options);
         }
 
-        private Dictionary<string, object> BuildObjectFromNode(JsonTreeNode node)
+        private static string FormatKey(string original, string fallback, bool useCamelCase)
+        {
+            var name = string.IsNullOrEmpty(original) ? fallback : original;
+            if (!useCamelCase || string.IsNullOrEmpty(name) || char.IsLower(name[0]))
+            {
+                return name;
+            }
+
+            return char.ToLowerInvariant(name[0]) + name.Substring(1);
+        }
+
+        private Dictionary<string, object> BuildObjectFromNode(JsonTreeNode node, bool useCamelCase)
         {
             var result = new Dictionary<string, object>();
 
@@ -45,7 +58,8 @@ namespace JsonContentTranslator
                 {
                     if (!string.IsNullOrEmpty(prop.DisplayName))
                     {
-                        result[prop.DisplayName] = prop.ValueTranslation ?? string.Empty;
+                        var key = FormatKey(prop.OriginalName, prop.DisplayName, useCamelCase);
+                        result[key] = prop.ValueTranslation ?? string.Empty;
                     }
                 }
             }
@@ -57,7 +71,8 @@ namespace JsonContentTranslator
                 {
                     if (!string.IsNullOrEmpty(child.DisplayName))
                     {
-                        result[child.DisplayName] = BuildObjectFromNode(child);
+                        var key = FormatKey(child.OriginalName, child.DisplayName, useCamelCase);
+                        result[key] = BuildObjectFromNode(child, useCamelCase);
                     }
                 }
             }

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -111,6 +111,15 @@ namespace JsonContentTranslator
             }.WithIconLeft("fa-magnifying-glass");
             buttonGoToNextEmpty.Bind(Button.IsVisibleProperty, new Binding(nameof(viewModel.IsLoaded)));
 
+            var checkBoxCamelCase = new CheckBox
+            {
+                Content = "camelCase",
+                Margin = new Thickness(5, 10, 5, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                [!CheckBox.IsCheckedProperty] = new Binding(nameof(viewModel.UseCamelCase)) { Mode = BindingMode.TwoWay },
+            };
+            checkBoxCamelCase.Bind(CheckBox.IsVisibleProperty, new Binding(nameof(viewModel.IsLoaded)));
+
             var buttonImportSe4Xml = new Button
             {
                 Content = "Import SE 4 xml...",
@@ -209,6 +218,7 @@ namespace JsonContentTranslator
                     buttonOpen,
                     buttonSave,
                     buttonGoToNextEmpty,
+                    checkBoxCamelCase,
                     buttonImportSe4Xml,
                     labelFrom,
                     comboBoxSourceLanguage,

--- a/src/MainWindowViewModel.cs
+++ b/src/MainWindowViewModel.cs
@@ -35,6 +35,7 @@ namespace JsonTreeViewEditor
         [ObservableProperty] private TranslationPair _selectedSourceLanguage;
         [ObservableProperty] private ObservableCollection<TranslationPair> _targetLanguages;
         [ObservableProperty] private TranslationPair _selectedTargetLanguage;
+        [ObservableProperty] private bool _useCamelCase = true;
 
         public Window? Window { get; set; }
         public TreeView JsonTreeView { get; internal set; }
@@ -401,7 +402,7 @@ namespace JsonTreeViewEditor
                 return;
             }
 
-            var json = JsonTree[0].ConvertTreeToJson();
+            var json = JsonTree[0].ConvertTreeToJson(UseCamelCase);
             File.WriteAllText(filePath, json, Encoding.UTF8);
             _hasUnsavedChanges = false;
             UpdateWindowTitle();
@@ -412,6 +413,7 @@ namespace JsonTreeViewEditor
             var node = new JsonTreeNode
             {
                 DisplayName = name.CapitalizeFirstLetter(),
+                OriginalName = name,
                 Element = element,
                 ValueKind = element.ValueKind,
             };


### PR DESCRIPTION
## Summary
- Preserve the source property name on parse via a new `OriginalName` field on `JsonTreeNode`/`JsonGridItem`, and use it (instead of the PascalCased `DisplayName`) when writing JSON.
- New `UseCamelCase` view-model flag (default `true`) lowercases the first letter of each output key; toggle it off to preserve the source's original casing.
- Toolbar gets a `camelCase` checkbox bound to the flag, visible once a file is loaded.

## Test plan
- [ ] Open a base JSON whose top-level keys are PascalCased (e.g. an SE language file) and save — verify written file uses camelCase keys.
- [ ] Untick the `camelCase` checkbox and save — verify keys are written exactly as in the source.
- [ ] Confirm tree/grid UI still shows PascalCased display names (unchanged).

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)